### PR TITLE
Fix navigation if previous is subslide

### DIFF
--- a/atest/resources/Docs.resource
+++ b/atest/resources/Docs.resource
@@ -31,6 +31,14 @@ Start Notebook Deck With Anchors
     Make Markdown Cell    back to [Hello World](#Hello-World)    Hello World
     Select A Slide Type    4    subslide    s1-01-new-slide.png
 
+Start Notebook Deck With Subslides
+    [Documentation]    Make a few cells with subslides
+    Start Basic Notebook Deck
+    Make Markdown Cell    subslide 1    subslide 1
+    Select A Slide Type    4    subslide    s2-01-new-subslide.png
+    Make Markdown Cell    subslide 2    subslide 2
+    Select A Slide Type    5    subslide    s2-02-new-subslide.png
+
 Tear Down Interactive Suite
     [Documentation]    Clean up after this suite.
     Execute JupyterLab Command    Close All Tabs

--- a/atest/suites/lab/02-navigate.robot
+++ b/atest/suites/lab/02-navigate.robot
@@ -34,3 +34,12 @@ Build and Navigate a Notebook Slide With Anchors
     Click Element    css:${CSS_DECK_VISIBLE} a[href^\="#Hello-World"]
     Wait Until Element Is Visible    css:${CSS_DECK_VISIBLE} h1
     Capture Page Screenshot    s1-02-back.png
+
+Build and Navigate a Notebook Slide With Subslides
+    [Documentation]    Build and navigate a slide with subslides.
+    Set Attempt Screenshot Directory    lab${/}navigate${/}subslides
+    Start Notebook Deck With Subslides
+    Really Back Up Deck With Keyboard    s2-03-backup.png    subslide 1
+    Really Back Up Deck With Keyboard    s2-04-backup.png    item4567
+    Really Advance Notebook Deck With Keyboard    s2-05-advance.png    subslide 1
+    Really Advance Notebook Deck With Keyboard    s2-06-advance.png    subslide 2

--- a/js/jupyterlab-slideshow/src/notebook/presenter.ts
+++ b/js/jupyterlab-slideshow/src/notebook/presenter.ts
@@ -848,6 +848,9 @@ export class NotebookPresenter implements IPresenter<NotebookPanel> {
           } else if (f0) {
             f0.down = index;
             extent.up = f0.index;
+          } else if (ss0) {
+            ss0.down = index;
+            extent.up = ss0.index;
           } else if (s0) {
             let lastOnScreen = this._lastOnScreenOf(s0.index, extents);
             if (lastOnScreen) {


### PR DESCRIPTION
Initially opened at https://github.com/deathbeds/jupyterlab-deck/pull/62

Fixes a a navigation problem with sub-slide.

A sub-slide (1) without fragment and (2) followed by another sub-slide is ignored in the navigation.
This PR solve it by checking if a sub-slide is preceded by another sub-slide.

## Checklist

- [ ] ran `doit lint` locally

## References

Expressed in https://github.com/deathbeds/jupyterlab-deck/issues/49

> Expected: the following subslide "Subslide1" is displayed
> Got: the subslide "subslide2" is displayed

## Code changes

When creating the extent (navigation) for a sub-slide, check if there is a previous sub-slide.

## User-facing changes

None except for the navigation.

## Backwards-incompatible changes

None