### PR TITLE
Optionally shows the code cell prompt (execution count)

### DIFF
--- a/js/jupyterlab-slideshow/schema/plugin.json
+++ b/js/jupyterlab-slideshow/schema/plugin.json
@@ -37,6 +37,12 @@
       "default": false,
       "description": "Whether presentation mode is currently active."
     },
+    "showCodeCellPrompt": {
+      "title": "Show execution count",
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to show the execution count (input prompt) in Notebook presentation"
+    },
     "stylePresets": {
       "title": "Style Presets",
       "$ref": "#/definitions/style-presets",

--- a/js/jupyterlab-slideshow/src/manager.ts
+++ b/js/jupyterlab-slideshow/src/manager.ts
@@ -57,6 +57,7 @@ export class DeckManager implements IDeckManager {
   protected _layover: Layover | null = null;
   protected _activePresenter: IPresenter<Widget> | null = null;
   protected _activeWidgetStack: Widget[] = [];
+  protected _showCodeCellPrompt: boolean = false;
 
   constructor(options: DeckManager.IOptions) {
     this._appStarted = options.appStarted;
@@ -105,6 +106,10 @@ export class DeckManager implements IDeckManager {
 
   public get layoverChanged(): ISignal<IDeckManager, void> {
     return this._layoverChanged;
+  }
+
+  public get showCodeCellPrompt(): boolean {
+    return this._showCodeCellPrompt
   }
 
   /**
@@ -524,6 +529,12 @@ export class DeckManager implements IDeckManager {
     let composite: IDeckSettings;
     composite = settings.composite as IDeckSettings;
     const active = composite.active === true;
+
+    const showCodeCellPrompt = composite.showCodeCellPrompt === true;
+    if (showCodeCellPrompt !== this._showCodeCellPrompt) {
+      this._showCodeCellPrompt = showCodeCellPrompt;
+      void this._addDeckStyles();
+    }
 
     if (active && !this._active) {
       void this.start();

--- a/js/jupyterlab-slideshow/src/notebook/presenter.ts
+++ b/js/jupyterlab-slideshow/src/notebook/presenter.ts
@@ -79,6 +79,11 @@ export class NotebookPresenter implements IPresenter<NotebookPanel> {
 
   public async style(panel: NotebookPanel): Promise<void> {
     panel.addClass(CSS.deck);
+    if (this._manager.showCodeCellPrompt) {
+      panel.addClass(CSS.showCodeCellPrompt);
+    } else {
+      panel.removeClass(CSS.showCodeCellPrompt);
+    }
     this._manager.cacheStyle(panel.node, panel.content.node);
   }
 

--- a/js/jupyterlab-slideshow/src/tokens.ts
+++ b/js/jupyterlab-slideshow/src/tokens.ts
@@ -56,6 +56,7 @@ export interface IDeckManager {
   setLayerScope(layerScope: TLayerScope | null): void;
   getPartStyles(): GlobalStyles | null;
   setPartStyles(styles: GlobalStyles | null): void;
+  readonly showCodeCellPrompt: boolean;
 }
 
 export const IDeckManager = new Token<IDeckManager>(PLUGIN_ID);
@@ -128,6 +129,7 @@ export namespace CSS {
   export const stop = 'jp-deck-mod-stop';
   export const widgetStack = 'jp-Deck-Remote-WidgetStack';
   // notebook
+  export const showCodeCellPrompt = 'jp-deck-showCodeCellPrompt';
   export const direction = 'jp-deck-mod-direction';
   export const onScreen = 'jp-deck-mod-onscreen';
   export const visible = 'jp-deck-mod-visible';
@@ -266,6 +268,7 @@ export interface IStylePreset {
 
 export interface IDeckSettings {
   active?: boolean;
+  showCodeCellPrompt?: boolean;
   stylePresets?: {
     [key: string]: Partial<IStylePreset>;
   };

--- a/js/jupyterlab-slideshow/style/notebook.css
+++ b/js/jupyterlab-slideshow/style/notebook.css
@@ -1,9 +1,21 @@
 /** heavy ui tweaks **/
-.jp-Deck .jp-InputPrompt,
-.jp-Deck .jp-OutputPrompt,
+.jp-Deck:not(.jp-deck-showCodeCellPrompt) .jp-InputPrompt,
+.jp-Deck:not(.jp-deck-showCodeCellPrompt) .jp-OutputPrompt,
 .jp-Deck .jp-Notebook-footer,
 .jp-Deck .jp-cell-toolbar {
   display: none;
+}
+
+.jp-Deck.jp-deck-showCodeCellPrompt .jp-InputPrompt,
+.jp-Deck.jp-deck-showCodeCellPrompt .jp-OutputPrompt {
+  /* uses visibility instead of display to keep alignment between markdown and code cell */
+  visibility: hidden;
+}
+
+.jp-Deck.jp-deck-showCodeCellPrompt .jp-CodeCell .jp-InputPrompt,
+.jp-Deck.jp-deck-showCodeCellPrompt .jp-CodeCell .jp-OutputPrompt {
+  display: inherit;
+  visibility: inherit;
 }
 
 .jp-Deck .jp-NotebookPanel-toolbar {


### PR DESCRIPTION
Allows displaying the input prompt (execution count) for Notebook code cell.

## Checklist

- [ ] ran `doit lint` locally

## References

https://github.com/deathbeds/jupyterlab-deck/issues/67

## Code changes

- a setting (`showCodeCellPrompt`) to enable or disable display of the prompt
- a class (`.jp-deck-showCodeCellPrompt`) added to the panel, depending on the value of the setting
- CSS that hides the prompt or not, depending on the class on the panel

If the panel do not have the class, prompt on all cells are not displayed: `display: none`.
If the panel have the class, prompt of code cell are displayed, and prompt of other cells are hidden (`visibility: hidden`), to keep left-align between cells.

## User-facing changes

Display the code cell prompt if expected.

## Backwards-incompatible changes

None