### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### `0.3.1`
+
+- [#16](https://github.com/jupyterlab-contrib/jupyterlab-slideshow/pull/16) Rename npm package
+
 ### `0.3.0`
 
 - [#9](https://github.com/jupyterlab-contrib/jupyterlab-slideshow/pull/9) Fix CI installation

--- a/dodo.py
+++ b/dodo.py
@@ -24,8 +24,8 @@ if DOT_ENV.exists():
 
 class C:
     NPM_NAME = "jupyterlab-slideshow"
-    OLD_VERSION = "0.2.1"
-    VERSION = "0.3.0"
+    OLD_VERSION = "0.3.0"
+    VERSION = "0.3.1"
     JS_VERSION = (
         VERSION.replace("a", "-alpha.").replace("b", "-beta.").replace("rc", "-rc.")
     )

--- a/js/jupyterlab-slideshow/README.md
+++ b/js/jupyterlab-slideshow/README.md
@@ -2,7 +2,7 @@
 
 ---
 
-# `jupyterlab-slideshow`
+# jupyterlab-slideshow
 
 <!-- |        docs         |                      install                      |       extend        |                        demo                         |                                    ci                                     |
 | :-----------------: | :-----------------------------------------------: | :-----------------: | :-------------------------------------------------: | :-----------------------------------------------------------------------: |
@@ -34,6 +34,8 @@
   https://codecov.io/gh/deathbeds/jupyterlab-deck/branch/main/graph/badge.svg?token=LS6ZzwKlqU -->
 
 > Lightweight presentations for JupyterLab
+
+Fork of <https://github.com/deathbeds/jupyterlab-deck>
 
 ---
 

--- a/js/jupyterlab-slideshow/package.json
+++ b/js/jupyterlab-slideshow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-slideshow",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Lightweight presentations for JupyterLab",
   "license": "BSD-3-Clause",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "jupyterlab-slideshow"
-version = "0.3.0"
+version = "0.3.1"
 readme = "README.md"
 classifiers = [
     "Framework :: Jupyter :: JupyterLab :: 3",


### PR DESCRIPTION
## Checklist

- [ ] ran `doit lint` locally

## References

Bump version for next release including the [renaming of npm package](https://github.com/jupyterlab-contrib/jupyterlab-slideshow/pull/16)

## Code changes


## User-facing changes

## Backwards-incompatible changes

