### PR TITLE
Get back to previous fragment when using shift+space

### DIFF
--- a/js/jupyterlab-slideshow/src/notebook/presenter.ts
+++ b/js/jupyterlab-slideshow/src/notebook/presenter.ts
@@ -411,7 +411,7 @@ export class NotebookPresenter implements IPresenter<NotebookPanel> {
       panel.content.activeCellIndex = moveTo;
     } else if (fromExtentAlternate != null) {
       let moveTo = fromExtentAlternate;
-      if (['back', 'forward'].includes(direction)) {
+      if (alternate && ['back', 'forward'].includes(alternate)) {
         moveTo = this._slideBackup(extents, activeCellIndex, fromExtentAlternate);
       }
       panel.content.activeCellIndex = moveTo;


### PR DESCRIPTION
## Checklist

- [ ] ran `doit lint` locally

## References

Follow up https://github.com/jupyterlab-contrib/jupyterlab-slideshow/pull/11 to fix the navigation back to a sub-slide or fragment when using `shift+space`.
See https://github.com/jupyterlab-contrib/jupyterlab-slideshow/pull/10#issuecomment-2585381968 for context

## Code changes

Uses extent redirection when moving back to a slide using `shift+space`.

## User-facing changes

none

## Backwards-incompatible changes

None

cc. @nthiery 