### PR TITLE
Prevent dependabot from using yarn 4

### DIFF
--- a/js/_meta/package.json
+++ b/js/_meta/package.json
@@ -24,5 +24,6 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "jupyterlab-slideshow": "workspace:^"
-  }
+  },
+  "packageManager": "yarn@3.5.0"
 }

--- a/js/jupyterlab-slideshow/package.json
+++ b/js/jupyterlab-slideshow/package.json
@@ -56,5 +56,6 @@
         "bundled": true
       }
     }
-  }
+  },
+  "packageManager": "yarn@3.5.0"
 }

--- a/package.json
+++ b/package.json
@@ -198,5 +198,6 @@
       "color-function-notation": null,
       "selector-class-pattern": null
     }
-  }
+  },
+  "packageManager": "yarn@3.5.0"
 }


### PR DESCRIPTION
Prevent dependabot from using yarn 4, which modifies the *yarn.lock* file.

## Checklist

- [ ] ran `doit lint` locally

## References

See https://github.com/jupyterlab/extension-template/pull/79 for more information.

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None
