### PR TITLE
Use toolbar registry for the deck button and move it to the right

### DIFF
--- a/js/jupyterlab-slideshow/schema/plugin.json
+++ b/js/jupyterlab-slideshow/schema/plugin.json
@@ -30,6 +30,15 @@
   "description": "Configure Deck Settings",
   "jupyter.lab.setting-icon": "deck:start",
   "jupyter.lab.setting-icon-label": "Decks",
+  "jupyter.lab.toolbars": {
+    "Notebook": [
+      {
+        "name": "deck",
+        "command": "deck:toggle",
+        "rank": 900
+      }
+    ]
+  },
   "properties": {
     "active": {
       "title": "Activate Deck",

--- a/js/jupyterlab-slideshow/src/notebook/extension.ts
+++ b/js/jupyterlab-slideshow/src/notebook/extension.ts
@@ -1,45 +1,27 @@
-import { CommandToolbarButton } from '@jupyterlab/apputils';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { NotebookPanel, INotebookModel } from '@jupyterlab/notebook';
-import { CommandRegistry } from '@lumino/commands';
-import { IDisposable, DisposableDelegate } from '@lumino/disposable';
-
-import { CommandIds } from '../tokens';
 
 import { NotebookPresenter } from './presenter';
 
 export class NotebookDeckExtension
   implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel>
 {
-  private _commands: CommandRegistry;
   private _presenter: NotebookPresenter;
 
   constructor(options: DeckExtension.IOptions) {
-    this._commands = options.commands;
     this._presenter = options.presenter;
   }
 
   createNew(
     panel: NotebookPanel,
     context: DocumentRegistry.IContext<INotebookModel>,
-  ): IDisposable {
-    const button = new CommandToolbarButton({
-      commands: this._commands,
-      label: '',
-      id: CommandIds.toggle,
-    });
-
-    panel.toolbar.insertItem(5, 'deck', button);
-
+  ): void {
     this._presenter.preparePanel(panel);
-
-    return new DisposableDelegate(() => button.dispose());
   }
 }
 
 export namespace DeckExtension {
   export interface IOptions {
-    commands: CommandRegistry;
     presenter: NotebookPresenter;
   }
 }

--- a/js/jupyterlab-slideshow/src/plugin.ts
+++ b/js/jupyterlab-slideshow/src/plugin.ts
@@ -100,7 +100,7 @@ const notebookPlugin: JupyterFrontEndPlugin<void> = {
 
     app.docRegistry.addWidgetExtension(
       NOTEBOOK_FACTORY,
-      new NotebookDeckExtension({ commands, presenter }),
+      new NotebookDeckExtension({ presenter }),
     );
   },
 };


### PR DESCRIPTION
## Checklist

- [ ] ran `doit lint` locally

## References

Fixes #17 

![image](https://github.com/user-attachments/assets/9fb2ddd6-d32c-4d98-a987-90c6240c91b5)

## Code changes

- use the settings to add the deck button to the notebook toolbar
- move the button to the right side of the toolbar

#### Note
The settings cannot be used for markdown files because the toolbar registry seems to be the same for other file types.

## User-facing changes

Button moved on le right of the toolbar.

## Backwards-incompatible changes

None
