### PR TITLE
Allow stopping presentation with escape key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         if: always()
 
       - name: Upload (dist)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jupyterlab-slideshow-dist-${{ github.run_number }}
           path: ./dist
@@ -179,7 +179,7 @@ jobs:
 
   #     - name: upload (reports)
   #       if: always()
-  #       uses: actions/upload-artifact@v3
+  #       uses: actions/upload-artifact@v4
   #       with:
   #         name: jupyterlab-slideshow-lint-reports-${{ github.run_number }}
   #         path: ./build/reports
@@ -258,7 +258,7 @@ jobs:
 
   #     - name: upload (reports)
   #       if: always()
-  #       uses: actions/upload-artifact@v3
+  #       uses: actions/upload-artifact@v4
   #       with:
   #         name: |-
   #           jupyterlab-slideshow-reports-${{ matrix.os }}-${{matrix.python-version }}-${{ github.run_number }}

--- a/js/jupyterlab-slideshow/src/manager.ts
+++ b/js/jupyterlab-slideshow/src/manager.ts
@@ -28,6 +28,7 @@ import {
   IDeckSettings,
   TSlideType,
   TLayerScope,
+  STOP_KEY,
 } from './tokens';
 import { DesignTools } from './tools/design';
 import type { Layover } from './tools/layover';
@@ -341,6 +342,12 @@ export class DeckManager implements IDeckManager {
         selector: `.${CSS.remote}`,
       });
     }
+    this._commands.addKeyBinding({
+      command: CommandIds.stop,
+      args: {},
+      keys: STOP_KEY,
+      selector: `.${CSS.remote}`,
+    });
   }
 
   public async showLayover() {

--- a/js/jupyterlab-slideshow/src/markdown/presenter.ts
+++ b/js/jupyterlab-slideshow/src/markdown/presenter.ts
@@ -18,6 +18,7 @@ import {
   COMPOUND_KEYS,
   MARKDOWN_MIMETYPES,
   MARKDOWN_PREVIEW_FACTORY,
+  STOP_KEY,
 } from '../tokens';
 
 export class SimpleMarkdownPresenter
@@ -149,6 +150,12 @@ export class SimpleMarkdownPresenter
         selector: `.${CSS.deck} .${CSS.markdownViewer}`,
       });
     }
+    this._commands.addKeyBinding({
+      command: CommandIds.stop,
+      args: {},
+      keys: STOP_KEY,
+      selector: `.${CSS.deck} .${CSS.markdownViewer}`,
+    });
   }
 
   protected _addWindowListeners() {

--- a/js/jupyterlab-slideshow/src/notebook/presenter.ts
+++ b/js/jupyterlab-slideshow/src/notebook/presenter.ts
@@ -35,6 +35,7 @@ import {
   META,
   ICellDeckMetadata,
   TLayerScope,
+  STOP_KEY,
 } from '../tokens';
 import type { Layover } from '../tools/layover';
 
@@ -341,6 +342,12 @@ export class NotebookPresenter implements IPresenter<NotebookPanel> {
         selector: `.${CSS.deck} .jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus`,
       });
     }
+    this._commands.addKeyBinding({
+      command: CommandIds.stop,
+      args: {},
+      keys: STOP_KEY,
+      selector: `.${CSS.deck} .jp-Notebook.jp-mod-commandMode:not(.jp-mod-readWrite) :focus`,
+    });
   }
 
   public async canGo(panel: NotebookPanel): Promise<Partial<TCanGoDirection>> {

--- a/js/jupyterlab-slideshow/src/tokens.ts
+++ b/js/jupyterlab-slideshow/src/tokens.ts
@@ -192,6 +192,8 @@ export const DIRECTION_KEYS: Record<TDirection, string[]> = {
   down: ['ArrowDown'],
 };
 
+export const STOP_KEY: string[] = ['Escape'];
+
 export const COMPOUND_LABEL = new Map<[TDirection, TDirection], string>([
   [[DIRECTION.down, DIRECTION.forward], 'Go to next fragment, subslide, or slide'],
   [[DIRECTION.up, DIRECTION.back], 'Go to previous fragment, subslide, or slide'],


### PR DESCRIPTION
## Code changes

This PR adds a keybinding (`Escape`) to stop the current presentation.

[record-2025-04-22_11.30.28.webm](https://github.com/user-attachments/assets/7c4f787c-c2e2-409a-a366-1d0b39383bbc)

## User-facing changes

Stop presentation when hitting `Escape`.

## Backwards-incompatible changes

Should not.

cc. @nthiery 