### PR TITLE
Fix the metadata key

### DIFF
--- a/examples/Layers.ipynb
+++ b/examples/Layers.ipynb
@@ -59,7 +59,7 @@
       }
      }
     },
-    "jupyterlab-deck": {
+    "jupyterlab-slideshow": {
      "layer": "deck"
     },
     "tags": []
@@ -127,7 +127,7 @@
       }
      }
     },
-    "jupyterlab-deck": {
+    "jupyterlab-slideshow": {
      "layer": "fragment"
     },
     "tags": []
@@ -167,7 +167,7 @@
       }
      }
     },
-    "jupyterlab-deck": {
+    "jupyterlab-slideshow": {
      "layer": "slide"
     },
     "tags": []
@@ -208,7 +208,7 @@
       }
      }
     },
-    "jupyterlab-deck": {
+    "jupyterlab-slideshow": {
      "layer": "stack"
     },
     "tags": []

--- a/js/jupyterlab-slideshow/src/notebook/metadata.tsx
+++ b/js/jupyterlab-slideshow/src/notebook/metadata.tsx
@@ -170,7 +170,7 @@ export namespace DeckCellEditor {
     update() {
       this._activeMeta =
         (this._activeCell?.model
-          ? (getCellMetadata(this._activeCell?.model, META.deck) as ICellDeckMetadata)
+          ? (getCellMetadata(this._activeCell?.model, META.metadataKey) as ICellDeckMetadata)
           : null) || JSONExt.emptyObject;
       this.stateChanged.emit(void 0);
     }
@@ -258,9 +258,9 @@ export namespace DeckCellEditor {
 
     protected _setDeckMetadata(newMeta: ICellDeckMetadata, cell: Cell<ICellModel>) {
       if (Object.keys(newMeta).length) {
-        setCellMetadata(cell.model, META.deck, newMeta);
+        setCellMetadata(cell.model, META.metadataKey, newMeta);
       } else {
-        deleteCellMetadata(cell.model, META.deck);
+        deleteCellMetadata(cell.model, META.metadataKey);
       }
     }
 

--- a/js/jupyterlab-slideshow/src/notebook/presenter.ts
+++ b/js/jupyterlab-slideshow/src/notebook/presenter.ts
@@ -202,7 +202,7 @@ export class NotebookPresenter implements IPresenter<NotebookPanel> {
   public getLayerScope(panel: NotebookPanel): string | null {
     let { activeCell } = panel.content;
     if (activeCell) {
-      const meta = (getCellMetadata(activeCell.model, META.deck) || emptyObject) as any;
+      const meta = (getCellMetadata(activeCell.model, META.metadataKey) || emptyObject) as any;
       return (meta[META.layer] || null) as TLayerScope;
     }
     return null;
@@ -214,15 +214,15 @@ export class NotebookPresenter implements IPresenter<NotebookPanel> {
       return;
     }
     let oldMeta =
-      ((getCellMetadata(activeCell.model, META.deck) || emptyObject) as Record<
+      ((getCellMetadata(activeCell.model, META.metadataKey) || emptyObject) as Record<
         string,
         any
       >) || null;
     if (layerScope == null) {
       if (oldMeta == null) {
-        deleteCellMetadata(activeCell.model, META.deck);
+        deleteCellMetadata(activeCell.model, META.metadataKey);
       } else {
-        setCellMetadata(activeCell.model, META.deck, {
+        setCellMetadata(activeCell.model, META.metadataKey, {
           ...oldMeta,
           [META.layer]: layerScope,
         });
@@ -231,7 +231,7 @@ export class NotebookPresenter implements IPresenter<NotebookPanel> {
       if (oldMeta == null) {
         oldMeta = {};
       }
-      setCellMetadata(activeCell.model, META.deck, {
+      setCellMetadata(activeCell.model, META.metadataKey, {
         ...oldMeta,
         [META.layer]: layerScope,
       });
@@ -636,7 +636,7 @@ export class NotebookPresenter implements IPresenter<NotebookPanel> {
 
   /** Get layer metadata from `jupyterlab-slideshow` namespace */
   protected _getCellDeckMetadata(cell: ICellModel): ICellDeckMetadata {
-    return (getCellMetadata(cell, META.deck) ||
+    return (getCellMetadata(cell, META.metadataKey) ||
       emptyObject) as any as ICellDeckMetadata;
   }
 

--- a/js/jupyterlab-slideshow/src/tokens.ts
+++ b/js/jupyterlab-slideshow/src/tokens.ts
@@ -230,7 +230,7 @@ export namespace META {
   export const nullSelector = '';
   export const presentingCell = `body[data-jp-deck-mode='presenting'] &`;
   // deck
-  export const deck = NS.split('/')[1];
+  export const metadataKey = NS;
   export const layer = 'layer';
 }
 


### PR DESCRIPTION
After renaming the package, the metadata was undefined, because it was parsed from [the package name](https://github.com/jupyterlab-contrib/jupyterlab-slideshow/blob/0655f64a342ec6dbf79825e42a323ae02b4336f1/js/jupyterlab-slideshow/src/tokens.ts#L233).

This PR uses the full package name (`jupyterlab-slideshow`) as metadata key.

## Checklist

- [ ] ran `doit lint` locally

## References

Fixes #35 

![image](https://github.com/user-attachments/assets/c99ea02f-6a7e-43cf-92e7-8dd53e7b8e6b)


## Code changes

Update the name and value of the variable used as root metadata key for the jupyterlab-slideshow metadata.
